### PR TITLE
Add ability to ignore properties

### DIFF
--- a/src/org/dt/japper/JapperIgnore.java
+++ b/src/org/dt/japper/JapperIgnore.java
@@ -1,0 +1,21 @@
+package org.dt.japper;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation to tell the mapper to ignore this property.
+ * <p>
+ *     This should be placed on either the getter or the setter method of the property.
+ *     Placing it on either one will tell Japper to ignore this property during matching.
+ * </p>
+ * <p>
+ *     The initial use-case for this is to allow for the prevention of infinite loops.
+ * </p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface JapperIgnore {
+}

--- a/test-src/org/dt/japper/SimpleRecursiveModelTest.java
+++ b/test-src/org/dt/japper/SimpleRecursiveModelTest.java
@@ -1,0 +1,76 @@
+package org.dt.japper;
+
+/*
+ * Copyright (c) 2018, David Sykes and Tomasz Orzechowski
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * - Neither the name David Sykes nor Tomasz Orzechowski may be used to endorse
+ * or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ */
+
+
+import org.dt.japper.testmodel.RecursiveIgnoredPartModel;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.sql.Connection;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class SimpleRecursiveModelTest {
+
+    private static TestData testData;
+
+    @BeforeClass
+    public static void setupDB() throws Exception {
+        testData = new TestData();
+        testData.create();
+    }
+
+    private static final String SQL_PARTS =
+            "   SELECT *"
+          + "     FROM part"
+          + " ORDER BY partno"
+            ;
+
+    @Test
+    public void mapPartsIgnoringRecursion() throws Exception {
+        Connection conn = testData.connect();
+
+        List<RecursiveIgnoredPartModel> parts = Japper.query(conn, RecursiveIgnoredPartModel.class, SQL_PARTS);
+        assertEquals(3, parts.size());
+
+        RecursiveIgnoredPartModel part = parts.get(0);
+        assertEquals("123456", part.getPartno());
+        assertEquals("FAB", part.getPartType());
+
+        conn.close();
+    }
+
+}

--- a/test-src/org/dt/japper/testmodel/RecursiveIgnoredPartModel.java
+++ b/test-src/org/dt/japper/testmodel/RecursiveIgnoredPartModel.java
@@ -1,0 +1,87 @@
+package org.dt.japper.testmodel;
+
+/*
+ * Copyright (c) 2018, David Sykes and Tomasz Orzechowski
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * - Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * - Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ *
+ * - Neither the name David Sykes nor Tomasz Orzechowski may be used to endorse
+ * or promote products derived from this software without specific prior written
+ * permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *
+ */
+
+import org.dt.japper.JapperIgnore;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+public class RecursiveIgnoredPartModel {
+
+    private String partno;
+    private String description;
+    private String partType;
+    private Map<String, BigDecimal> flexFields;
+
+    // This is the recursive part!
+    private RecursiveIgnoredPartModel otherPart;
+
+    public String getPartno() {
+        return partno;
+    }
+    public void setPartno(String partno) {
+        this.partno = partno;
+    }
+    public String getDescription() {
+        return description;
+    }
+    public void setDescription(String description) {
+        this.description = description;
+    }
+    public String getPartType() {
+        return partType;
+    }
+    public void setPartType(String partType) {
+        this.partType = partType;
+    }
+
+
+    public Map<String, BigDecimal> getFlexFields() {
+        return flexFields;
+    }
+
+    public void setFlexFields(Map<String, BigDecimal> flexFields) {
+        this.flexFields = flexFields;
+    }
+
+    public RecursiveIgnoredPartModel getOtherPart() {
+        return otherPart;
+    }
+
+    @JapperIgnore
+    public void setOtherPart(RecursiveIgnoredPartModel otherPart) {
+        this.otherPart = otherPart;
+    }
+}


### PR DESCRIPTION
First step on work to allow for recursive models.

This first step is to be able to marked properties to be ignored during matching. This allows users to at least create model classes that are recursive and not have Japper go into an infinite loop